### PR TITLE
Change PARENT tag of exons to transcript id, not gene id

### DIFF
--- a/Community/lib/perl/GeneModelLocations.pm
+++ b/Community/lib/perl/GeneModelLocations.pm
@@ -261,10 +261,8 @@ sub bioperlFeaturesFromGeneSourceId {
   foreach my $exonHash (sort { $a->{start} * $a->{strand} <=> $b->{start} * $b->{strand} } values %{$geneModelHash->{exons}}) {
     die "exon strand cannot be set to 0" if($exonHash->{strand} == 0);
 
-    my $parent = join(",", @{$exonHash->{transcripts}});
-
-
-    my $exonFeature = GUS::Community::GeneModelLocations::Exon->new ( -start => $exonHash->{start}, 
+    foreach my $transcriptSourceId (@{$exonHash->{transcripts}}) {
+      my $exonFeature = GUS::Community::GeneModelLocations::Exon->new ( -start => $exonHash->{start}, 
                                                    -end => $exonHash->{end}, 
                                                    -seq_id => $exonHash->{sequence_source_id},
                                                    -strand => $exonHash->{strand}, 
@@ -272,18 +270,17 @@ sub bioperlFeaturesFromGeneSourceId {
                                                    -source_tag => $sourceTag, 
                                                    -tag    => { ID => $exonHash->{source_id},
                                                                 NA_FEATURE_ID => $exonHash->{na_feature_id},
-                                                                PARENT => $parent,
+                                                                PARENT => $transcriptSourceId,
+                                                                PARENT_NA_FEATURE_ID => $geneModelHash->{transcripts}{$transcriptSourceId}{na_feature_id},
                                                                 GENE_NA_FEATURE_ID => $geneModelHash->{na_feature_id},
                                                                 NA_SEQUENCE_ID => $geneModelHash->{na_sequence_id},
                                                    });
 
 
-    foreach my $transcriptId (@{$exonHash->{transcripts}}) {
-      my $transcriptFeature = $transcriptMap{$transcriptId};
+      my $transcriptFeature = $transcriptMap{$transcriptSourceId};
       $transcriptFeature->add_exon($exonFeature);
+      push @exonFeatures, $exonFeature;
     }
-
-    push @exonFeatures, $exonFeature
   }
 
   my @sortedExonFeatures = sort { $a->start <=> $b->start} @exonFeatures;


### PR DESCRIPTION
The code must have done something different in the past, but the exons are ID'ed per transcript anyway, for example (with this change):
```
  DB<10> x $feature
0  GUS::Community::GeneModelLocations::Exon=HASH(0xad67030)
   '_gsf_seq_id' => 'Pf3D7_06_v3'
   '_gsf_tag_hash' => HASH(0x8b1a510)
      'GENE_NA_FEATURE_ID' => ARRAY(0x9ba1c50)
         0  824711
      'ID' => ARRAY(0x71d2940)
         0  'exon_PF3D7_0621350.1-E3'
      'NA_FEATURE_ID' => ARRAY(0xc0a84c8)
         0  824712
      'NA_SEQUENCE_ID' => ARRAY(0x8174b48)
         0  19978
      'PARENT' => ARRAY(0x5d8cfb8)
         0  'PF3D7_0621350.1'
      'PARENT_NA_FEATURE_ID' => ARRAY(0x80cd1b0)
         0  824715
```

This change is intended to affect one place: ApiCommonData::Load::Plugin::InsertFeatureLocation. I looked through the usages of the module, here is what I've found:

```
$PROJECT_HOME/ApiCommonData/Load/bin/makeGff.pl
$PROJECT_HOME/ApiCommonData/Load/bin/makeGff4GenbankSubmission.pl
$PROJECT_HOME/ApiCommonData/Load/bin/makeGff4BRC4.pl
strips the tags - ok

$PROJECT_HOME/ApiCommonData/Load/bin/mercatorGffDump.pl
should be okay - Mercator shouldn't use tags?

$PROJECT_HOME/ApiCommonData/Load/bin/makeGtf.pl
wanted the exons per transcript and had a workaround for it - removed the workaround

$PROJECT_HOME/ApiCommonData/Load/bin/mapArrayElementsToGenes.pl
$PROJECT_HOME/ApiCommonData/Load/bin/makeGeneFootprintFile.pl
$PROJECT_HOME/ApiCommonData/Load/plugin/perl/InsertMassSpecFeaturesAndSummaries.pm
only uses coordinates. should be ok

$PROJECT_HOME/ApiCommonData/Load/bin/processSequenceVariations.pl
uses a different part of the module, calls getAgpMap which doesn't intersect with the change - ok

$PROJECT_HOME/ApiCommonData/Load/plugin/perl/InsertFeatureLocation.pm
intended change

$PROJECT_HOME/ApiCommonData/Load/plugin/perl/InsertPARFeatures.pm
$PROJECT_HOME/ApiCommonData/Load/plugin/perl/InsertPARIntronJunctions.pm
imports the module without using it - removed

$PROJECT_HOME/ApiCommonData/Load/plugin/perl/InsertSpliceSiteGenes.pm
works on CDSes not exons - should be ok
```